### PR TITLE
Add PID to temp SRAM config file

### DIFF
--- a/cacti_wrapper.py
+++ b/cacti_wrapper.py
@@ -200,8 +200,8 @@ class CactiWrapper:
         if not math.ceil(math.log2(desired_n_banks)) == math.floor(math.log2(desired_n_banks)):
             print('WARN: Cacti-plug-in... n_banks attribute is not a power of 2:', desired_n_banks)
             print('corrected "n_banks": ', n_banks)
-        cfg_file_name = self.output_prefix + datetime.now().strftime("%m_%d_%H_%M_%S") + '_SRAM.cfg' if self.output_prefix is not '' \
-                        else  datetime.now().strftime("%m_%d_%H_%M_%S") + '_SRAM.cfg'
+        cfg_file_name = self.output_prefix + datetime.now().strftime("%m_%d_%H_%M_%S") + f'_{os.getpid()}' + '_SRAM.cfg' if self.output_prefix is not '' \
+                        else  datetime.now().strftime("%m_%d_%H_%M_%S") + f'_{os.getpid()}' + '_SRAM.cfg'
         cfg_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), cfg_file_name)
         self.cacti_wrapper_for_SRAM(cacti_exec_dir, tech_node, size_in_bytes, wordsize_in_bytes, n_rw_ports,
                                     n_banks, cfg_file_path)


### PR DESCRIPTION
This filename currently contains a timestamp (with second granularity) to differentiate it from other Accelergy/Cacti runs, but this scheme can fail if we run multiple Accelergy instances in parallel at the same time. A fix is to add the PID of the current process to the filename.